### PR TITLE
数据的保存路径固定到aegisub的安装目录下

### DIFF
--- a/函数库3.3.lua
+++ b/函数库3.3.lua
@@ -8,7 +8,7 @@ script_version = "3.3"
 
 function get_fxs()
 	local lines={}
-	funs=io.open("funs.lua","a+")
+	funs=io.open(aegisub.decode_path("?data").."/funs.lua","a+")
 	for line in funs:lines() do
 		lines[#lines+1]=line
 	end
@@ -27,7 +27,7 @@ return fxs_tbl
 end
 
 function file_rewrite()
-	funs=io.open("funs.lua","w+")
+	funs=io.open(aegisub.decode_path("?data").."/funs.lua","w+")
 	for i,fun in ipairs(fxs) do
 		funs:write("function_name\n"..fun.name.."\n")
 		funs:write("function_start\n"..fun.fx.."\n".."function_end\n")


### PR DESCRIPTION
之前`func.lua`一直保存在`aegisub安装目录\log`下，某天突然发现漂移到`aegisub安装目录\feedDump`下，导致读取失败。为确保保存位置的固定性，写死保存的目录，固定到aegisub的安装目录下。